### PR TITLE
Update dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClickHouse"
 uuid = "82f2e89e-b495-11e9-1d9d-fb40d7cf2130"
 authors = ["Joel Höner <athre0z@zyantific.com>", "Alexandr Romanenko <waralex@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -14,8 +14,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-CategoricalArrays = "0.8.1"
-DataFrames = "0.21"
-DecFP = "1.0.0"
-ProgressMeter = "1.3"
+CategoricalArrays = "0.10"
+DataFrames = "1.3"
+DecFP = "1.3"
+ProgressMeter = "1.7"
 julia = "1"

--- a/src/columns/LowCardinality.jl
+++ b/src/columns/LowCardinality.jl
@@ -1,4 +1,5 @@
 using UUIDs
+
 is_ch_type(::Val{:LowCardinality})  = true
 can_be_nullable(::Val{:LowCardinality}) = false
 
@@ -45,8 +46,8 @@ end
 function make_result(index::CategoricalVector{T}, keys, is_nullable) where {T}
 
     result = is_nullable ?
-            CategoricalVector{Union{T, Missing}}(undef, 0, levels = get.(index))  :
-            CategoricalVector{T}(undef, 0, levels = get.(index))
+            CategoricalVector{Union{T, Missing}}(undef, 0, levels = unwrap.(index))  :
+            CategoricalVector{T}(undef, 0, levels = unwrap.(index))
     result.refs = keys
     return result
 end


### PR DESCRIPTION
This PR simply updates all dependencies to their latest version. `CategoricalArrays` deprecated their `get` function, suggesting to using `unwrap` instead, which I did. All tests are passing.

Resolves https://github.com/JuliaDatabases/ClickHouse.jl/issues/28.