### PR TITLE
allow enum empty strings

### DIFF
--- a/src/columns/Enum.jl
+++ b/src/columns/Enum.jl
@@ -5,7 +5,7 @@ result_type(::Val{:Enum16}, args...)  = CategoricalVector{String}
 
 const ENUM_RE_ARG = r"""
 
-           '((?:(?:[^'])|(?:\\'))+)'
+           '((?:(?:[^'])|(?:\\'))*)'
            \s*=\s*
            (-?\d+)
            \s*$


### PR DESCRIPTION
> An empty string is allowed
(https://clickhouse.com/docs/en/sql-reference/data-types/enum/#general-rules-and-usage)

for example `Enum8('' = -128, 'X' = 0, 'Y' = 1)`