### PR TITLE
remove unnecessary generic type parameters to avoid warning messages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClickHouse"
 uuid = "82f2e89e-b495-11e9-1d9d-fb40d7cf2130"
 authors = ["Joel Höner <athre0z@zyantific.com>", "Alexandr Romanenko <waralex@gmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -81,8 +81,8 @@ The iterable is expected to yield values of type `Dict{Symbol, Any}`.
 function insert(
     sock::ClickHouseSock,
     table::AbstractString,
-    iter,
-)::Nothing where T
+    iter
+)::Nothing
     # TODO: We might want to escape the table name here...
     @using_socket sock begin
         write_query(sock, "INSERT INTO $(table) VALUES")

--- a/src/columns/Nullable.jl
+++ b/src/columns/Nullable.jl
@@ -89,9 +89,12 @@ end
 
 #For Nothing columns,
 #(i.e. column of nulls in CHtypes of CH, of missing column in Julia types)
-function write_col_data(sock::ClickHouseSock,
-                                data::AbstractVector{Missing},
-                                ::Val{:Nullable}, nested::TypeAst) where {T}
+function write_col_data(
+    sock::ClickHouseSock,
+    data::AbstractVector{Missing},
+    ::Val{:Nullable},
+    nested::TypeAst
+)
     nested.name != :Nothing &&
         error("Vector{Missing} can be writen only to Nullable(Nothing) column")
     missing_map = Vector{UInt8}(undef, length(data))


### PR DESCRIPTION
Solves issue [https://github.com/JuliaDatabases/ClickHouse.jl/issues/34](https://github.com/JuliaDatabases/ClickHouse.jl/issues/34)

Non-breaking, hygene pull request.

Unit-tests all run successfully.