### PR TITLE
Add a method to handle missing BitVector to allow read in from parquet url 

### DIFF
--- a/src/columns/Nullable.jl
+++ b/src/columns/Nullable.jl
@@ -16,6 +16,11 @@ convert_to_missings(data::Vector{T}) where {T} =
 convert_to_missings(data::CategoricalVector{T}) where {T} =
                             convert(CategoricalVector{Union{T, Missing}}, data)
 
+# Add a method to handle BitVector                            
+convert_to_missings(data::BitVector) = 
+                            convert(Vector{Union{Bool, Missing}}, data)
+
+
 function read_col_data(sock::ClickHouseSock, num_rows::VarUInt,
                                             ::Val{:Nullable}, nested::TypeAst)
 


### PR DESCRIPTION
right now the below throws this error. This PR adds 1 line to fix that 
```
query = """
SELECT *
FROM url('https://huggingface.co/datasets/maharshipandya/spotify-tracks-dataset/resolve/refs%2Fconvert%2Fparquet/default/train/0000.parquet')
SETTINGS enable_url_encoding=0, max_http_get_redirects=1
"""
ClickHouse.select_df(conn, query)
```
```
ERROR: MethodError: no method matching convert_to_missings(::BitVector)

Closest candidates are:
  convert_to_missings(::CategoricalArrays.CategoricalVector{T}) where T
   @ ClickHouse ~/.julia/packages/ClickHouse/aWH9P/src/columns/Nullable.jl:16
  convert_to_missings(::Vector{T}) where T
   @ ClickHouse ~/.julia/packages/ClickHouse/aWH9P/src/columns/Nullable.jl:13

Stacktrace:
  [1] read_col_data(sock::ClickHouseSock, num_rows::ClickHouse.VarUInt, ::Val{:Nullable}, nested::ClickHouse.TypeAst)
    @ ClickHouse ~/.julia/packages/ClickHouse/aWH9P/src/columns/Nullable.jl:24
  [2] read_col_data
    @ ~/.julia/packages/ClickHouse/aWH9P/src/columns/Interfaces.jl:47 [inlined]
  [3] read_col(sock::ClickHouseSock, num_rows::ClickHouse.VarUInt)
    @ ClickHouse ~/.julia/packages/ClickHouse/aWH9P/src/tcp/DataBlocks.jl:65
  [4] #6
    @ ./generator.jl:0 [inlined]
  [5] iterate
    @ ./generator.jl:47 [inlined]
  [6] collect_to!
    @ ./array.jl:892 [inlined]
  [7] collect_to_with_first!
    @ ./array.jl:870 [inlined]
  [8] collect(itr::Base.Generator{UnitRange{UInt64}, ClickHouse.var"#6#7"{ClickHouseSock, ClickHouse.VarUInt}})
    @ Base ./array.jl:844
  [9] chread(sock::ClickHouseSock, ::Type{Block})
    @ ClickHouse ~/.julia/packages/ClickHouse/aWH9P/src/tcp/DataBlocks.jl:130
 [10] chread(sock::ClickHouseSock, ::Type{ClickHouse.ServerData})
    @ ClickHouse ~/.julia/packages/ClickHouse/aWH9P/src/tcp/Macro.jl:23
 [11] read_packet(sock::ClickHouseSock, ::Type{ClickHouse.ServerCodes})
    @ ClickHouse ~/.julia/packages/ClickHouse/aWH9P/src/tcp/Packets.jl:51
 [12] read_server_packet(sock::ClickHouseSock)
    @ ClickHouse ~/.julia/packages/ClickHouse/aWH9P/src/tcp/Packets.jl:57
```

